### PR TITLE
Feat/menu preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,24 @@ tsman edit # edit the config file of the current session
 tsman delete <session_name>
 ```
 
-## Menu keybindings:
+### Open a menu that contains all saved sessions
 
-| command              | action                                 |
-| -------------------- | -------------------------------------- |
-| `Esc` / `C-c`        | Exit menu                              |
-| `Up arrow` / `C-p`   | Select previous item                   |
-| `Down arrow` / `C-n` | Select next item                       |
-| `C-e`                | Edit config file of selected session   |
-| `C-d`                | Delete config file of selected session |
-| `Enter`              | Open selected session                  |
+```bash
+tsman menu
+tsman menu -p # open the menu with the preview pane on
+```
+
+#### Menu keybindings:
+
+| command              | action                                    |
+| -------------------- | ----------------------------------------- |
+| `Esc` / `C-c`        | Exit menu                                 |
+| `Up arrow` / `C-p`   | Select previous item                      |
+| `Down arrow` / `C-n` | Select next item                          |
+| `C-e`                | Edit config file of selected session      |
+| `C-d`                | Delete config file of selected session    |
+| `C-t`                | Toggle the visibility of the preview pane |
+| `Enter`              | Open selected session                     |
 
 ## Configuration
 
@@ -59,14 +67,14 @@ Example config:
 `~/.tmux.conf`:
 
 ```bash
-bind -r f run-shell "tmux neww 'tsman menu'"
+bind -r f run-shell "tmux neww 'tsman menu -p'"
 bind -r C-s run-shell "tsman save"
 ```
 
 `~/.zshrc`:
 
 ```bash
-alias mux-fd="tsman menu"
+alias mux-fd="tsman menu -p"
 ```
 
 If you want to set up a custom location to store session config files set the

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -3,7 +3,8 @@ use std::process::Command;
 
 use crate::cli::{Args, Commands};
 use crate::persistence::*;
-use crate::tmux_interface::*;
+use crate::tmux::interface::*;
+use crate::tmux::session::Session;
 use crate::tui::{self, MenuAction, MenuUi};
 
 use anyhow::{Context, Result};

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -17,7 +17,7 @@ pub fn handle(args: Args) -> Result<()> {
         Commands::Open { session_name } => open(&session_name),
         Commands::Edit { session_name } => edit(session_name.as_deref()),
         Commands::Delete { session_name } => delete(&session_name),
-        Commands::Menu => menu(),
+        Commands::Menu { preview } => menu(preview),
     }
 }
 
@@ -85,11 +85,11 @@ fn delete(session_name: &str) -> Result<()> {
     Ok(())
 }
 
-fn menu() -> Result<()> {
+fn menu(show_preview: bool) -> Result<()> {
     let mut terminal = tui::init()?;
 
     let session_names = list_saved_sessions()?;
-    let mut menu_ui = MenuUi::new(session_names);
+    let mut menu_ui = MenuUi::new(session_names, show_preview);
     menu_ui.run(&mut terminal)?;
 
     tui::restore(terminal)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,5 +25,8 @@ pub enum Commands {
     Delete { session_name: String },
 
     /// display menu containing all sessions
-    Menu,
+    Menu {
+        #[clap(long, short, help = "Show preview pane on start up")]
+        preview: bool,
+    },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod actions;
 mod cli;
 mod persistence;
-mod tmux_interface;
+mod tmux;
 mod tui;
 
 use anyhow::{Context, Result};

--- a/src/tmux/interface.rs
+++ b/src/tmux/interface.rs
@@ -6,122 +6,15 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
 use shell_escape::escape;
 use tempfile::NamedTempFile;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Pane {
-    index: String,
-    current_command: Option<String>,
-    work_dir: String,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Window {
-    index: String,
-    name: String,
-    layout: String,
-    panes: Vec<Pane>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Session {
-    pub name: String,
-    work_dir: String,
-    windows: Vec<Window>,
-}
+use crate::tmux::session::*;
 
 const TMUX_FIELD_SEPARATOR: &str = " ";
 const TMUX_LINE_SEPARATOR: &str = "\n";
 
 const ATTACH_DELAY: u64 = 700;
-
-impl Pane {
-    pub fn get_preview(&self, show_index: bool) -> String {
-        let mut preview = String::new();
-
-        if show_index {
-            preview += &format!("({}) ", self.index);
-        }
-
-        preview += &format!(
-            "{}",
-            match self.current_command.as_ref() {
-                Some(cmd) => cmd,
-                None => "_",
-            }
-        );
-
-        preview
-    }
-}
-
-impl Window {
-    pub fn get_preview(&self, add_connector: bool) -> String {
-        if self.panes.len() == 1 {
-            return format!(
-                "{}: {}\n",
-                self.name,
-                self.panes[0].get_preview(false)
-            );
-        }
-
-        let mut preview = format!("{}:\n", self.name);
-
-        let connector = if add_connector { "║" } else { " " };
-
-        let mut pane_idx = 0;
-        while pane_idx < self.panes.len() - 1 {
-            preview += &format!(
-                " {}  ╠═ {}\n",
-                connector,
-                self.panes[pane_idx].get_preview(true)
-            );
-            pane_idx += 1;
-        }
-
-        preview += &format!(
-            " {}  ╚═ {}\n",
-            connector,
-            self.panes[pane_idx].get_preview(true)
-        );
-
-        preview
-    }
-}
-
-impl Session {
-    pub fn get_preview(&self) -> String {
-        let mut preview = format!("{}:\n", self.name);
-
-        let mut window_idx = 0;
-        while window_idx < self.windows.len() - 1 {
-            let window = &self.windows[window_idx];
-            let end_connector =
-                if window.panes.len() > 1 { "╦═" } else { "" };
-
-            preview +=
-                &format!(" ╠══{} {}", end_connector, window.get_preview(true));
-            window_idx += 1;
-        }
-
-        let last_window = &self.windows[window_idx];
-        let end_connector = if last_window.panes.len() > 1 {
-            "╦═"
-        } else {
-            ""
-        };
-
-        preview += &format!(
-            " ╚══{} {}",
-            end_connector,
-            last_window.get_preview(false)
-        );
-
-        preview
-    }
-}
 
 pub fn get_session() -> Result<Session> {
     let (name, path) =

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -1,0 +1,2 @@
+pub mod interface;
+pub mod session;

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -1,0 +1,109 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Pane {
+    pub index: String,
+    pub current_command: Option<String>,
+    pub work_dir: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Window {
+    pub index: String,
+    pub name: String,
+    pub layout: String,
+    pub panes: Vec<Pane>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Session {
+    pub name: String,
+    pub work_dir: String,
+    pub windows: Vec<Window>,
+}
+
+impl Pane {
+    pub fn get_preview(&self, show_index: bool) -> String {
+        let mut preview = String::new();
+
+        if show_index {
+            preview += &format!("({}) ", self.index);
+        }
+
+        preview += &format!(
+            "{}",
+            match self.current_command.as_ref() {
+                Some(cmd) => cmd,
+                None => "_",
+            }
+        );
+
+        preview
+    }
+}
+
+impl Window {
+    pub fn get_preview(&self, add_connector: bool) -> String {
+        if self.panes.len() == 1 {
+            return format!(
+                "{}: {}\n",
+                self.name,
+                self.panes[0].get_preview(false)
+            );
+        }
+
+        let mut preview = format!("{}:\n", self.name);
+
+        let connector = if add_connector { "║" } else { " " };
+
+        let mut pane_idx = 0;
+        while pane_idx < self.panes.len() - 1 {
+            preview += &format!(
+                " {}  ╠═ {}\n",
+                connector,
+                self.panes[pane_idx].get_preview(true)
+            );
+            pane_idx += 1;
+        }
+
+        preview += &format!(
+            " {}  ╚═ {}\n",
+            connector,
+            self.panes[pane_idx].get_preview(true)
+        );
+
+        preview
+    }
+}
+
+impl Session {
+    pub fn get_preview(&self) -> String {
+        let mut preview = format!("{}:\n", self.name);
+
+        let mut window_idx = 0;
+        while window_idx < self.windows.len() - 1 {
+            let window = &self.windows[window_idx];
+            let end_connector =
+                if window.panes.len() > 1 { "╦═" } else { "" };
+
+            preview +=
+                &format!(" ╠══{} {}", end_connector, window.get_preview(true));
+            window_idx += 1;
+        }
+
+        let last_window = &self.windows[window_idx];
+        let end_connector = if last_window.panes.len() > 1 {
+            "╦═"
+        } else {
+            ""
+        };
+
+        preview += &format!(
+            " ╚══{} {}",
+            end_connector,
+            last_window.get_preview(false)
+        );
+
+        preview
+    }
+}

--- a/src/tmux_interface.rs
+++ b/src/tmux_interface.rs
@@ -37,6 +37,92 @@ const TMUX_LINE_SEPARATOR: &str = "\n";
 
 const ATTACH_DELAY: u64 = 700;
 
+impl Pane {
+    pub fn get_preview(&self, show_index: bool) -> String {
+        let mut preview = String::new();
+
+        if show_index {
+            preview += &format!("({}) ", self.index);
+        }
+
+        preview += &format!(
+            "{}",
+            match self.current_command.as_ref() {
+                Some(cmd) => cmd,
+                None => "_",
+            }
+        );
+
+        preview
+    }
+}
+
+impl Window {
+    pub fn get_preview(&self, add_connector: bool) -> String {
+        if self.panes.len() == 1 {
+            return format!(
+                "{}: {}\n",
+                self.name,
+                self.panes[0].get_preview(false)
+            );
+        }
+
+        let mut preview = format!("{}:\n", self.name);
+
+        let connector = if add_connector { "║" } else { " " };
+
+        let mut pane_idx = 0;
+        while pane_idx < self.panes.len() - 1 {
+            preview += &format!(
+                " {}  ╠═ {}\n",
+                connector,
+                self.panes[pane_idx].get_preview(true)
+            );
+            pane_idx += 1;
+        }
+
+        preview += &format!(
+            " {}  ╚═ {}\n",
+            connector,
+            self.panes[pane_idx].get_preview(true)
+        );
+
+        preview
+    }
+}
+
+impl Session {
+    pub fn get_preview(&self) -> String {
+        let mut preview = format!("{}:\n", self.name);
+
+        let mut window_idx = 0;
+        while window_idx < self.windows.len() - 1 {
+            let window = &self.windows[window_idx];
+            let end_connector =
+                if window.panes.len() > 1 { "╦═" } else { "" };
+
+            preview +=
+                &format!(" ╠══{} {}", end_connector, window.get_preview(true));
+            window_idx += 1;
+        }
+
+        let last_window = &self.windows[window_idx];
+        let end_connector = if last_window.panes.len() > 1 {
+            "╦═"
+        } else {
+            ""
+        };
+
+        preview += &format!(
+            " ╚══{} {}",
+            end_connector,
+            last_window.get_preview(false)
+        );
+
+        preview
+    }
+}
+
 pub fn get_session() -> Result<Session> {
     let (name, path) =
         get_session_info().context("Failed to get session info")?;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -25,7 +25,8 @@ use ratatui::{
 
 use anyhow::Result;
 
-use crate::{persistence::load_session_from_config, tmux_interface::Session};
+use crate::persistence::load_session_from_config;
+use crate::tmux::session::Session;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum MenuAction {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -71,7 +71,7 @@ impl fmt::Debug for MenuUi {
 }
 
 impl MenuUi {
-    pub fn new(items: Vec<String>) -> Self {
+    pub fn new(items: Vec<String>, show_preview: bool) -> Self {
         let mut list_state = ListState::default();
         list_state.select(Some(0));
 
@@ -82,7 +82,7 @@ impl MenuUi {
             list_state,
             matcher: fuzzy_matcher::skim::SkimMatcherV2::default(),
             action_queue: VecDeque::new(),
-            show_preview: true,
+            show_preview,
             exit: false,
         }
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -48,6 +48,8 @@ pub struct MenuUi {
 
     action_queue: VecDeque<MenuActionItem>,
 
+    show_preview: bool,
+
     exit: bool,
 }
 
@@ -59,6 +61,7 @@ impl fmt::Debug for MenuUi {
             .field("input", &self.input)
             .field("list_state", &self.list_state)
             .field("action_queue", &self.action_queue)
+            .field("show_preview", &self.show_preview)
             .field("exit", &self.exit)
             .finish()
     }
@@ -76,6 +79,7 @@ impl MenuUi {
             list_state,
             matcher: fuzzy_matcher::skim::SkimMatcherV2::default(),
             action_queue: VecDeque::new(),
+            show_preview: true,
             exit: false,
         }
     }
@@ -94,13 +98,20 @@ impl MenuUi {
     }
 
     fn draw(&mut self, frame: &mut Frame) {
-        let chunks = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([
-                Constraint::Percentage(60),
-                Constraint::Percentage(40),
-            ])
-            .split(frame.area());
+        let chunks = if self.show_preview {
+            Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([
+                    Constraint::Percentage(60),
+                    Constraint::Percentage(40),
+                ])
+                .split(frame.area())
+        } else {
+            Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(100)])
+                .split(frame.area())
+        };
 
         let left_chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -137,13 +148,16 @@ impl MenuUi {
                 vertical: 1,
             }),
         );
-        let preview_block =
-            Block::default().borders(Borders::ALL).title("Preview");
 
-        let preview_content = "test";
-        let preview = Paragraph::new(preview_content).block(preview_block);
+        if self.show_preview {
+            let preview_block =
+                Block::default().borders(Borders::ALL).title("Preview");
 
-        frame.render_widget(preview, chunks[1]);
+            let preview_content = "test";
+            let preview = Paragraph::new(preview_content).block(preview_block);
+
+            frame.render_widget(preview, chunks[1]);
+        }
     }
 
     fn handle_events(&mut self) -> Result<()> {
@@ -183,6 +197,7 @@ impl MenuUi {
                     }
                 }
                 KeyCode::Char('c') => self.exit = true,
+                KeyCode::Char('t') => self.show_preview = !self.show_preview,
                 _ => {}
             }
         } else {


### PR DESCRIPTION
- add a panel to the right of the menu that contains a tree-like preview of the currently selected session.
- the preview panel displays the windows, the panes in each window and the command that runs in each pane.
- add a shortcut to toggle the panel (C-t).
- add an option that starts the menu with the panel visible (-p). The panel is not visible by default.
- update the readme to include preview info.
<img width="1905" height="964" alt="image" src="https://github.com/user-attachments/assets/ed880836-9008-4fdb-aa12-a0709e40cdc4" />
