### PR TITLE
Add confirmation popup for delete in menu

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -17,7 +17,10 @@ pub fn handle(args: Args) -> Result<()> {
         Commands::Open { session_name } => open(&session_name),
         Commands::Edit { session_name } => edit(session_name.as_deref()),
         Commands::Delete { session_name } => delete(&session_name),
-        Commands::Menu { preview } => menu(preview),
+        Commands::Menu {
+            preview,
+            ask_for_confirmation,
+        } => menu(preview, ask_for_confirmation),
     }
 }
 
@@ -85,11 +88,12 @@ fn delete(session_name: &str) -> Result<()> {
     Ok(())
 }
 
-fn menu(show_preview: bool) -> Result<()> {
+fn menu(show_preview: bool, ask_for_confirmation: bool) -> Result<()> {
     let mut terminal = menu::init()?;
 
     let session_names = list_saved_sessions()?;
-    let mut menu_ui = MenuUi::new(session_names, show_preview);
+    let mut menu_ui =
+        MenuUi::new(session_names, show_preview, ask_for_confirmation);
     menu_ui.run(&mut terminal)?;
 
     menu::restore(terminal)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,5 +28,7 @@ pub enum Commands {
     Menu {
         #[clap(long, short, help = "Show preview pane on start up")]
         preview: bool,
+        #[clap(long, short, help = "Ask for confirmation before deleting")]
+        ask_for_confirmation: bool,
     },
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -204,7 +204,7 @@ impl MenuUi {
             .borders(Borders::ALL)
             .style(Style::default().bg(Color::DarkGray));
 
-        let paragraph = Paragraph::new(Line::from("y/n"))
+        let paragraph = Paragraph::new(Line::from("Y/n"))
             .block(block)
             .alignment(Alignment::Center);
 
@@ -238,11 +238,11 @@ impl MenuUi {
 
         if self.show_confirmation_popup {
             match key.code {
-                KeyCode::Char('y' | 'Y') => {
+                KeyCode::Char('y' | 'Y') | KeyCode::Enter => {
                     self.handle_delete();
                     self.show_confirmation_popup = false;
                 }
-                KeyCode::Char('n' | 'N') => {
+                KeyCode::Char('n' | 'N' | 'q') | KeyCode::Esc => {
                     self.show_confirmation_popup = false;
                 }
                 _ => {}

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -18,9 +18,11 @@ use fuzzy_matcher::{FuzzyMatcher, skim::SkimMatcherV2};
 
 use ratatui::{
     DefaultTerminal, Frame, Terminal,
-    layout::{Constraint, Direction, Layout},
+    layout::{Alignment, Constraint, Direction, Flex, Layout, Rect},
     prelude::CrosstermBackend,
-    widgets::{Block, Borders, List, ListState, Paragraph},
+    style::{Color, Style},
+    text::Line,
+    widgets::{Block, Borders, Clear, List, ListState, Paragraph},
 };
 
 use anyhow::Result;
@@ -51,6 +53,7 @@ pub struct MenuUi {
 
     action_queue: VecDeque<MenuActionItem>,
 
+    show_confirmation_popup: bool,
     show_preview: bool,
 
     exit: bool,
@@ -64,6 +67,7 @@ impl fmt::Debug for MenuUi {
             .field("input", &self.input)
             .field("list_state", &self.list_state)
             .field("action_queue", &self.action_queue)
+            .field("show_confirmation_popup", &self.show_confirmation_popup)
             .field("show_preview", &self.show_preview)
             .field("exit", &self.exit)
             .finish()
@@ -82,6 +86,7 @@ impl MenuUi {
             list_state,
             matcher: fuzzy_matcher::skim::SkimMatcherV2::default(),
             action_queue: VecDeque::new(),
+            show_confirmation_popup: false,
             show_preview,
             exit: false,
         }
@@ -153,6 +158,7 @@ impl MenuUi {
         );
 
         if self.show_preview {
+            // TODO: extract to function
             let preview_block =
                 Block::default().borders(Borders::ALL).title("Preview");
 
@@ -160,6 +166,10 @@ impl MenuUi {
             let preview = Paragraph::new(preview_content).block(preview_block);
 
             frame.render_widget(preview, chunks[1]);
+        }
+
+        if self.show_confirmation_popup {
+            MenuUi::draw_confirmation_popup(frame);
         }
     }
 
@@ -177,6 +187,34 @@ impl MenuUi {
         "".to_string()
     }
 
+    fn draw_confirmation_popup(f: &mut Frame) {
+        let popup_area = MenuUi::create_centered_rect(f.area(), 15, 3);
+
+        f.render_widget(Clear, popup_area);
+
+        let block = Block::default()
+            .title("Confirm")
+            .title_alignment(Alignment::Center)
+            .borders(Borders::ALL)
+            .style(Style::default().bg(Color::DarkGray));
+
+        let paragraph = Paragraph::new(Line::from("y/n"))
+            .block(block)
+            .alignment(Alignment::Center);
+
+        f.render_widget(paragraph, popup_area);
+    }
+
+    fn create_centered_rect(area: Rect, length_x: u16, length_y: u16) -> Rect {
+        let vertical =
+            Layout::vertical([Constraint::Length(length_y)]).flex(Flex::Center);
+        let horizontal = Layout::horizontal([Constraint::Length(length_x)])
+            .flex(Flex::Center);
+        let [area] = vertical.areas(area);
+        let [area] = horizontal.areas(area);
+        area
+    }
+
     fn handle_events(&mut self) -> Result<()> {
         if event::poll(Duration::from_millis(50))? {
             if let Event::Key(key) = event::read()? {
@@ -192,12 +230,9 @@ impl MenuUi {
             return;
         }
 
-        if key.modifiers.contains(KeyModifiers::CONTROL) {
+        if self.show_confirmation_popup {
             match key.code {
-                KeyCode::Char('p') => self.move_selection(-1),
-                KeyCode::Char('n') => self.move_selection(1),
-                KeyCode::Char('e') => self.enqueue_action(MenuAction::Edit),
-                KeyCode::Char('d') => {
+                KeyCode::Char('y' | 'Y') => {
                     if let Some(selection_idx) = self.list_state.selected() {
                         let selection =
                             match self.filtered_items.get(selection_idx) {
@@ -212,6 +247,23 @@ impl MenuUi {
                         self.list_state
                             .select(Some(selection_idx.saturating_sub(1)));
                     }
+                    self.show_confirmation_popup = false
+                }
+                KeyCode::Char('n' | 'N') => {
+                    self.show_confirmation_popup = false
+                }
+                _ => {}
+            }
+            return;
+        }
+
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            match key.code {
+                KeyCode::Char('p') => self.move_selection(-1),
+                KeyCode::Char('n') => self.move_selection(1),
+                KeyCode::Char('e') => self.enqueue_action(MenuAction::Edit),
+                KeyCode::Char('d') => {
+                    self.show_confirmation_popup = true;
                 }
                 KeyCode::Char('c') => self.exit = true,
                 KeyCode::Char('t') => self.show_preview = !self.show_preview,


### PR DESCRIPTION
- add a popup that ask for confirmation when triggering the delete action.
- make confirmation optional by adding the ask-for-confirmation option for the menu command.
- add multiple shortcut to confirm/abort deletion.
<img width="1910" height="967" alt="image" src="https://github.com/user-attachments/assets/dffaa23b-ea89-493e-ae55-f5a11e41eac3" />
